### PR TITLE
Require notifypy dependency, update notifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,8 @@ description = "Drop-in stopwatch utility"
 authors = [{name = "tmarquart", email=""}]
 license = {text = "MIT"}
 requires-python = ">=3.9"
+dependencies = ["notifypy>=1.4"]
 
-[project.optional-dependencies]
-notify = ["notifypy>=1.4"]
 
 [tool.setuptools.packages.find]
 where=["."]

--- a/requirements.md
+++ b/requirements.md
@@ -65,7 +65,7 @@ notifier	None	If None, use builtin notifypy backend.
 
 4.4 Sound
 	•	Parameters: sound: bool = False, sound_after: float = 60.0, sound_file (default = bundled ding.wav).
-	•	Plays via playsound; fallback to winsound.Beep (Windows) or ASCII bell (\a) when unavailable.
+        •       Sound playback uses notifypy's built-in audio support.
 	•	Fires when sound==True and elapsed ≥ sound_after.
 
 4.5 Incremental Mode
@@ -155,7 +155,7 @@ Spellbook is not documented in README; discoverable via dir(pocketwatch).
 
 Category	Requirement
 Python	3.9 +
-Dependencies	Hard: stdlib. Optional extras: notifypy → notify extra; playsound → sound extra.
+Dependencies    Hard: stdlib and notifypy.
 Wheel size	< 50 kB including WAVs
 Perf	Start + stop overhead ≤ 0.05 ms on 2 GHz CPU (no profiling).
 Platforms	Win / macOS / Linux; degrade silently if D-Bus, etc., absent.
@@ -184,9 +184,9 @@ recursive-include pocketwatch/data *.wav
 
 pyproject.toml excerpt
 
-[project.optional-dependencies]
-notify = ["notifypy>=1.4"]
-sound  = ["playsound>=1.3"]
+[project]
+dependencies = ["notifypy>=1.4"]
+
 
 
 ⸻

--- a/src/pocketwatch/core.py
+++ b/src/pocketwatch/core.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Protocol, Type, Literal
 from types import TracebackType
+from notifypy import Notify
 
 
 class NotifierProtocol(Protocol):
@@ -16,15 +17,9 @@ class NotifierProtocol(Protocol):
         ...
 
 
-try:
-    from notifypy import Notify
-except Exception:  # pragma: no cover - optional dep may be missing
-    Notify = None  # type: ignore
 
 
-def _default_notifier() -> Optional[NotifierProtocol]:
-    if Notify is None:
-        return None
+def _default_notifier() -> NotifierProtocol:
 
     class _Notifier:
         def send(self, title: str, message: str, sound_path: str | None = None) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,9 +3,28 @@ from __future__ import annotations
 import os
 import sys
 import pstats
+import types
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import importlib
+
+try:
+    importlib.import_module("notifypy")
+except Exception:
+    dummy = types.SimpleNamespace()
+    class DummyNotify:
+        def __init__(self) -> None:
+            self.title = ""
+            self.message = ""
+            self.audio: str | None = None
+
+        def send(self) -> None:
+            pass
+
+    dummy.Notify = DummyNotify
+    sys.modules['notifypy'] = dummy
 
 import src.pocketwatch.core as core
 from src.pocketwatch import Pocketwatch


### PR DESCRIPTION
## Summary
- enforce `notifypy` as a required dependency
- drop fallback logic for missing notification backend
- use notifypy for sound playback; remove playsound references
- update docs to reflect dependency change
- provide local notifypy stub for tests

## Testing
- `ruff check .`
- `mypy src/pocketwatch`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889465587508328afd4f23e8c311f46