### PR TITLE
Implement stopwatch decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Pocketwatch
+
+Pocketwatch is a small stopwatch utility for Python code blocks.
+
+```python
+from pocketwatch import Pocketwatch
+
+with Pocketwatch("load data"):
+    ...
+```
+
+## Bonus: Quick Stopwatch Decorator
+
+A lightweight decorator is available for convenience:
+
+```python
+from pocketwatch.decorators import stopwatch
+
+@stopwatch
+def do_work():
+    ...
+```
+
+This uses the function name as the label and logs the time. Pop-up is enabled by default.

--- a/requirements.md
+++ b/requirements.md
@@ -199,4 +199,32 @@ dependencies = ["notifypy>=1.4"]
 
 ⸻
 
+10 — Bonus `stopwatch` Decorator
+
+An optional sugar decorator for default use:
+
+```
+from pocketwatch.decorators import stopwatch
+
+@stopwatch
+def some_func(): ...
+
+@stopwatch(sound=True)
+def another(): ...
+```
+
+* Behaves like a `Pocketwatch(...)` with:
+  * `msg = func.__name__`
+  * `notify=True`, `notify_after=0.0`
+  * `sound=False`
+  * `log_mode="log"`
+
+This is not included in the main import path. Users must import manually:
+
+```python
+from pocketwatch.decorators import stopwatch
+```
+
+⸻
+
 End of requirements.

--- a/src/pocketwatch/decorators.py
+++ b/src/pocketwatch/decorators.py
@@ -1,0 +1,27 @@
+import functools
+from .core import Pocketwatch
+
+
+def stopwatch(*args, **kwargs):
+    """Lightweight decorator for timing functions."""
+    if args and callable(args[0]) and not kwargs:
+        fn = args[0]
+
+        @functools.wraps(fn)
+        def wrapper(*a, **kw):
+            with Pocketwatch(fn.__name__):
+                return fn(*a, **kw)
+
+        return wrapper
+
+    def decorator(fn):
+        msg = kwargs.pop("msg", fn.__name__)
+
+        @functools.wraps(fn)
+        def wrapper(*a, **kw):
+            with Pocketwatch(msg, **kwargs):
+                return fn(*a, **kw)
+
+        return wrapper
+
+    return decorator

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import importlib
+
+try:
+    importlib.import_module("notifypy")
+except Exception:
+    dummy = types.SimpleNamespace()
+    class DummyNotify:
+        def __init__(self) -> None:
+            self.title = ""
+            self.message = ""
+            self.audio: str | None = None
+
+        def send(self) -> None:
+            pass
+    dummy.Notify = DummyNotify
+    sys.modules["notifypy"] = dummy
+
+import src.pocketwatch.core as core
+from src.pocketwatch.decorators import stopwatch
+
+
+class FakeNotifier:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, str | None]] = []
+
+    def send(self, title: str, message: str, sound_path: str | None = None) -> None:
+        self.sent.append((title, message, sound_path))
+
+
+class Logger:
+    def __init__(self, storage: list[str]) -> None:
+        self.name = "Pocketwatch"
+        self._store = storage
+
+    def log(self, level: int, message: str) -> None:
+        self._store.append(message)
+
+    def addHandler(self, handler) -> None:  # pragma: no cover
+        pass
+
+    def removeHandler(self, handler) -> None:  # pragma: no cover
+        pass
+
+
+def _set_time(monkeypatch: pytest.MonkeyPatch, values: list[float]) -> None:
+    seq = iter(values)
+    monkeypatch.setattr(core.time, "perf_counter", lambda: next(seq))
+
+
+def test_stopwatch_default(monkeypatch):
+    _set_time(monkeypatch, [0.0, 1.0])
+    monkeypatch.setattr(core.atexit, "register", lambda *a, **k: None)
+    logger_msgs: list[str] = []
+
+    orig_get = core.logging.getLogger
+
+    def get_logger(name: str | None = None) -> Logger:
+        if name == "Pocketwatch":
+            return Logger(logger_msgs)
+        return orig_get(name)
+
+    monkeypatch.setattr(core.logging, "getLogger", get_logger)
+    n = FakeNotifier()
+    monkeypatch.setattr(core, "_default_notifier", lambda: n)
+
+    @stopwatch
+    def demo() -> str:
+        return "ok"
+
+    assert demo() == "ok"
+    assert any("demo completed in 1.000s" in m for m in logger_msgs)
+    assert n.sent
+
+
+def test_stopwatch_with_kwargs(monkeypatch, capsys):
+    _set_time(monkeypatch, [0.0, 2.0])
+    monkeypatch.setattr(core.atexit, "register", lambda *a, **k: None)
+    n = FakeNotifier()
+    monkeypatch.setattr(core, "_default_notifier", lambda: n)
+    logger_msgs: list[str] = []
+    orig_get = core.logging.getLogger
+
+    def get_logger(name: str | None = None) -> Logger:
+        if name == "Pocketwatch":
+            return Logger(logger_msgs)
+        return orig_get(name)
+
+    monkeypatch.setattr(core.logging, "getLogger", get_logger)
+
+    @stopwatch(msg="custom", notify=False, log_mode="print")
+    def task() -> None:
+        pass
+
+    task()
+    out = capsys.readouterr().out
+    assert "custom completed in 2.000s" in out
+    assert not n.sent


### PR DESCRIPTION
## Summary
- add stopwatch decorator with default Pocketwatch settings
- create new README
- document decorator in requirements
- add unit tests for decorator

## Testing
- `ruff check src tests`
- `cd src && MYPYPATH=. mypy --explicit-package-bases pocketwatch && cd ..`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68894b8bcc04832882db50990c596cea