### PR TITLE
Add top-level notify helper

### DIFF
--- a/src/pocketwatch/__init__.py
+++ b/src/pocketwatch/__init__.py
@@ -1,6 +1,6 @@
-from .core import Pocketwatch
+from .core import Pocketwatch, notify
 
-__all__ = ["Pocketwatch"]
+__all__ = ["Pocketwatch", "notify"]
 
 
 def __getattr__(name: str):
@@ -8,3 +8,4 @@ def __getattr__(name: str):
         from . import spellbook as sb
         return sb
     raise AttributeError(name)
+

--- a/src/pocketwatch/core.py
+++ b/src/pocketwatch/core.py
@@ -35,6 +35,24 @@ def _find_data_file(name: str) -> Path:
     return Path(__file__).with_name("data").joinpath(name)
 
 
+def notify(
+    message: str,
+    *,
+    title: str = "Pocketwatch",
+    sound: bool = False,
+    sound_file: str | Path | None = None,
+    notifier: NotifierProtocol | None = None,
+) -> None:
+    """Send a notification using Pocketwatch defaults."""
+
+    selected_notifier = notifier or _default_notifier()
+    sound_path: str | None = None
+    if sound:
+        path = Path(sound_file) if sound_file is not None else _find_data_file("ding.wav")
+        sound_path = str(path)
+    selected_notifier.send(title, message, sound_path)
+
+
 @dataclass
 class _Mark:
     note: str

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,7 +27,7 @@ except Exception:
     sys.modules["notifypy"] = dummy
 
 import src.pocketwatch.core as core
-from src.pocketwatch import Pocketwatch
+from src.pocketwatch import Pocketwatch, notify
 
 
 class FakeNotifier:
@@ -118,3 +118,20 @@ def test_atexit_stop(monkeypatch):
     pw._atexit_stop()
     assert pw.unexpected_exit
     assert pw._ended
+
+
+def test_notify_function_uses_notifier():
+    fake = FakeNotifier()
+    notify("hello", title="Custom", notifier=fake)
+    assert fake.sent == [("Custom", "hello", None)]
+
+
+def test_notify_function_default_sound():
+    fake = FakeNotifier()
+    notify("hello", sound=True, notifier=fake)
+    assert len(fake.sent) == 1
+    title, message, sound_path = fake.sent[0]
+    assert title == "Pocketwatch"
+    assert message == "hello"
+    assert sound_path is not None
+    assert sound_path.endswith("ding.wav")


### PR DESCRIPTION
## Summary
- add a reusable `notify` helper in the core module and expose it from the package root
- ensure the helper selects the default sound asset when audio is requested
- extend the core test suite to cover the new helper behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e175b87b34832884c72a1a1e8a5140